### PR TITLE
fix: read created item/track index from data.* in pattern & loop tools

### DIFF
--- a/reaper_mcp/tools/loops_tools.py
+++ b/reaper_mcp/tools/loops_tools.py
@@ -424,7 +424,8 @@ def register(mcp: FastMCP):
                 track_idx = existing[track_name]
             else:
                 result = await client.execute("track_create", name=track_name)
-                new_idx = result.get("index", result.get("track_index"))
+                tc_data = result.get("data", result)
+                new_idx = tc_data.get("index", tc_data.get("track_index"))
                 if new_idx is None:
                     errors.append({
                         "index": i,

--- a/reaper_mcp/tools/patterns_tools.py
+++ b/reaper_mcp/tools/patterns_tools.py
@@ -274,7 +274,8 @@ def register(mcp: FastMCP):
                 position=position_sec,
                 length=length_sec,
             )
-            item_index = int(result.get("item_index", result.get("index", 0)))
+            data = result.get("data", result)
+            item_index = int(data.get("item_index", data.get("index", 0)))
             created_item = True
 
         await client.execute(
@@ -398,7 +399,8 @@ def register(mcp: FastMCP):
                 position=position_sec,
                 length=length_sec,
             )
-            item_index = int(result.get("item_index", result.get("index", 0)))
+            data = result.get("data", result)
+            item_index = int(data.get("item_index", data.get("index", 0)))
             created_item = True
 
         await client.execute(


### PR DESCRIPTION
Two instances of the same root bug: bridge command responses nest their payload under `data` (`{"success":true,"data":{"index":N,...}}`), but several tools read the index from the **top level** and silently fall back to `0` / `None`.

## 1. Pattern tools — `create_drum_pattern`, `create_chord_progression`

```python
item_index = int(result.get("item_index", result.get("index", 0)))  # -> always 0
```

`item_create_midi` returns the index under `data`, so both keys are absent and it defaults to `0`, targeting project item 0 regardless of track. Only works when the target is the first item on track 0 (empty project); any multi-track use writes to the wrong item or fails:

```
[COMMAND_FAILED (2000)] Item is not on specified track
```

## 2. Loop library — `load_loops`

```python
new_idx = result.get("index", result.get("track_index"))  # -> None on create path
```

`track_create` also returns the index under `data`. When `load_loops` has to **create** a track (loading into any project without a pre-existing matching track name — the common case), `new_idx` is `None`, so it skips media insertion with `track_create returned no index` and loads 0 loops (even though the tracks get created).

## Fix

Read from `result["data"]` with a flat-dict fallback, matching how `chops_tools.py` already resolves `track_create`'s index. 3 call sites across 2 files.

## Verification (REAPER 7.78, Linux, stdio MCP path)

- `create_chord_progression(track_index=2, ...)` now creates the item on the correct track (`item_get_info` → `track_index: 2`) with the expected 12 notes.
- `load_loops(...)` into an empty project now creates Drums/Bass/Keys and inserts each loop (3/3 loaded, 0 errors) at the requested BPM.
