### PR TITLE
Add project metadata tools: render tags + Notes-tab Title/Author

### DIFF
--- a/reaper_mcp/tools/project_tools.py
+++ b/reaper_mcp/tools/project_tools.py
@@ -3,6 +3,42 @@ from reaper_mcp_shared.error_codes import ReaperMCPError, ErrorCode
 from reaper_mcp_shared.constants import ALLOWED_EXPORT_FORMATS
 from reaper_mcp_shared.path_safety import safe_path as _safe_path
 
+# Per-field byte cap for project render metadata. Tags are short descriptors;
+# anything approaching 1 KB almost certainly means wrong data was piped in.
+_METADATA_MAX_FIELD_BYTES = 1024
+
+
+def _build_metadata_payload(fields: dict) -> dict:
+    """Filter metadata fields down to non-empty values; raise if none remain.
+
+    Pure logic, extracted from ``project_set_metadata`` so the "empty strings
+    are ignored" / "at least one field required" / "per-field length cap"
+    contract can be unit-tested without REAPER.
+
+    Args:
+        fields: mapping of logical field name (title, author, ...) to value.
+
+    Returns:
+        The subset of ``fields`` whose value is truthy, as strings.
+
+    Raises:
+        ReaperMCPError: if every field is empty, or any field exceeds the cap.
+    """
+    payload = {k: str(v) for k, v in fields.items() if v}
+    if not payload:
+        raise ReaperMCPError(
+            ErrorCode.VALUE_OUT_OF_RANGE,
+            "at least one metadata field must be non-empty",
+        )
+    for k, v in payload.items():
+        if len(v.encode("utf-8")) > _METADATA_MAX_FIELD_BYTES:
+            raise ReaperMCPError(
+                ErrorCode.VALUE_OUT_OF_RANGE,
+                f"{k} too long ({len(v)} chars) — cap is "
+                f"{_METADATA_MAX_FIELD_BYTES} bytes per field",
+            )
+    return payload
+
 
 def register(mcp: FastMCP):
     from reaper_mcp.main import client
@@ -139,6 +175,63 @@ def register(mcp: FastMCP):
                 f"notes too long ({len(notes)} chars) — cap is 100 KB",
             )
         return await client.execute("project_set_notes", notes=notes)
+
+    @mcp.tool()
+    async def project_get_metadata() -> dict:
+        """Get project render metadata (title, author, album, comment, etc.).
+
+        These are the metadata fields REAPER embeds into rendered files
+        (ID3/BWF/Vorbis/APE tags) and substitutes into render-filename
+        templates ($title, $artist, ...). Reachable in the GUI via the
+        Render dialog's Metadata section.
+
+        Note: REAPER's API exposes WHICH fields are set (the tag list), but
+        not their VALUES — values are write-only via GetSetProjectInfo_String
+        (verified on REAPER 7.78). The returned `fields_set` maps each known
+        logical field to true when any of its tags is present; `tags_present`
+        gives the raw tag list (e.g. ["ID3:TIT2", "VORBIS:TITLE"]).
+        """
+        return await client.execute("project_get_metadata")
+
+    @mcp.tool()
+    async def project_set_metadata(
+        title: str = "",
+        author: str = "",
+        album: str = "",
+        comment: str = "",
+        genre: str = "",
+        year: str = "",
+        track_number: str = "",
+        composer: str = "",
+        isrc: str = "",
+        copyright: str = "",
+    ) -> dict:
+        """Set project render metadata fields. Non-empty fields are written.
+
+        Each field is written to every tag format REAPER can embed on render
+        (ID3 for mp3/wav-bwf, VORBIS for flac/ogg, APE for mpc/wv) so the
+        value survives regardless of the render format chosen later. Empty
+        strings are ignored and leave any existing value for that field
+        untouched. Setting a field again overwrites its previous value.
+
+        Args:
+            title: Track / project title.
+            author: Artist / author.
+            album: Album name.
+            comment: Free-form comment.
+            genre: Genre.
+            year: Year / date.
+            track_number: Track number.
+            composer: Composer.
+            isrc: ISRC code.
+            copyright: Copyright string.
+        """
+        payload = _build_metadata_payload({
+            "title": title, "author": author, "album": album, "comment": comment,
+            "genre": genre, "year": year, "track_number": track_number,
+            "composer": composer, "isrc": isrc, "copyright": copyright,
+        })
+        return await client.execute("project_set_metadata", **payload)
 
     @mcp.tool()
     async def project_set_grid(grid_division: float) -> dict:

--- a/reaper_mcp/tools/project_tools.py
+++ b/reaper_mcp/tools/project_tools.py
@@ -234,6 +234,35 @@ def register(mcp: FastMCP):
         return await client.execute("project_set_metadata", **payload)
 
     @mcp.tool()
+    async def project_get_notes_info() -> dict:
+        """Get the Title and Author fields of the Project Settings -> Notes tab.
+
+        These are the two single-line fields at the top of REAPER's Project
+        Settings -> Notes tab — distinct from both the notes free-text area
+        (project_get_notes / GetSetProjectNotes) and the render metadata
+        (project_get_metadata, which feeds file tags and filename templates).
+
+        Unlike render metadata, both fields return their actual stored values
+        (they are not write-only).
+        """
+        return await client.execute("project_get_notes_info")
+
+    @mcp.tool()
+    async def project_set_notes_info(title: str = "", author: str = "") -> dict:
+        """Set the Title and Author fields of the Project Settings -> Notes tab.
+
+        Non-empty fields are written; empty strings are ignored and leave any
+        existing value untouched. At least one field must be non-empty.
+
+        Args:
+            title: Project title (stored via the PROJECT_TITLE descriptor).
+            author: Project author (stored via PROJECT_AUTHOR; this is the same
+                value GetSetProjectAuthor() reads and writes).
+        """
+        payload = _build_metadata_payload({"title": title, "author": author})
+        return await client.execute("project_set_notes_info", **payload)
+
+    @mcp.tool()
     async def project_set_grid(grid_division: float) -> dict:
         """Set grid division (1.0=quarter, 0.5=eighth, 0.25=sixteenth).
 

--- a/reaper_scripts/reaper_mcp_server.lua
+++ b/reaper_scripts/reaper_mcp_server.lua
@@ -1117,6 +1117,74 @@ function project.project_set_notes(p)
   return {notes = stored}
 end
 
+-- ---- Project render metadata (RENDER_METADATA) ----
+-- REAPER stores per-render metadata (title, artist, album, ...) via the
+-- "RENDER_METADATA" string descriptor of GetSetProjectInfo_String. These
+-- values feed render-filename templates ($title, $artist) and are embedded
+-- as tags (ID3/BWF/Vorbis/APE) into rendered files.
+--
+-- Format, verified empirically on REAPER 7.78/linux:
+--   * SET  : one "TAG|value" pair per call; the API honors only the FIRST
+--            pair if several are concatenated in one string. Setting is
+--            ADDITIVE — new tags do not erase previously set ones.
+--   * GET  : returns a semicolon-separated list of tag NAMES that currently
+--            hold a value (e.g. "ID3:TIT2;ID3:TPE1"). The VALUES themselves
+--            are write-only — no descriptor exposes them back.
+--   * CLEAR: set "TAG|" with an empty value to remove a single tag.
+-- Each logical field maps to every tag format REAPER can embed, so the value
+-- survives regardless of the chosen render format (mp3/flac/ape/...).
+local METADATA_TAG_MAP = {
+  title        = {"ID3:TIT2", "VORBIS:TITLE",        "APE:Title"},
+  author       = {"ID3:TPE1", "VORBIS:ARTIST",       "APE:Artist"},
+  album        = {"ID3:TALB", "VORBIS:ALBUM",        "APE:Album"},
+  comment      = {"ID3:COMM", "VORBIS:COMMENT",      "APE:Comment"},
+  genre        = {"ID3:TCON", "VORBIS:GENRE",        "APE:Genre"},
+  year         = {"ID3:TYER", "VORBIS:DATE"},
+  track_number = {"ID3:TRCK", "VORBIS:TRACKNUMBER"},
+  composer     = {"ID3:TCOM", "VORBIS:COMPOSER",     "APE:Composer"},
+  isrc         = {"ID3:TSRC", "VORBIS:ISRC",         "APE:ISRC"},
+  copyright    = {"ID3:TCOP", "APE:Copyright"},
+}
+-- reverse lookup: any known tag -> its logical field
+local METADATA_TAG_TO_FIELD = {}
+for _field, _tags in pairs(METADATA_TAG_MAP) do
+  for _, _tag in ipairs(_tags) do METADATA_TAG_TO_FIELD[_tag] = _field end
+end
+
+function project.project_get_metadata(p)
+  local raw = select(2, reaper.GetSetProjectInfo_String(0, "RENDER_METADATA", "", false)) or ""
+  local tags_present = {}
+  local fields_set = {}
+  for tag in raw:gmatch("[^;]+") do
+    if tag ~= "" then
+      tags_present[#tags_present+1] = tag
+      local field = METADATA_TAG_TO_FIELD[tag]
+      if field then fields_set[field] = true end
+    end
+  end
+  return {
+    raw = raw,
+    tags_present = tags_present,
+    fields_set = fields_set,
+  }
+end
+
+function project.project_set_metadata(p)
+  local written = {}
+  for field, tags in pairs(METADATA_TAG_MAP) do
+    local value = p[field]
+    if value ~= nil and value ~= "" then
+      value = tostring(value)
+      for _, tag in ipairs(tags) do
+        reaper.GetSetProjectInfo_String(0, "RENDER_METADATA", tag .. "|" .. value, true)
+      end
+      written[field] = value
+    end
+  end
+  local raw = select(2, reaper.GetSetProjectInfo_String(0, "RENDER_METADATA", "", false)) or ""
+  return {written = written, tags_present_after = raw}
+end
+
 function project.project_main_action(p)
   -- Run a REAPER Main action by command_id. Used by high-level pipelines
   -- (e.g. bounce_stems uses action 40892 = render selected tracks to stems).

--- a/reaper_scripts/reaper_mcp_server.lua
+++ b/reaper_scripts/reaper_mcp_server.lua
@@ -1185,6 +1185,51 @@ function project.project_set_metadata(p)
   return {written = written, tags_present_after = raw}
 end
 
+-- ---- Project Settings -> Notes tab: Title / Author fields ----
+-- REAPER's Project Settings -> Notes tab has a free-text area (covered by
+-- project_get_notes / project_set_notes via GetSetProjectNotes) PLUS two
+-- single-line fields: Title and Author. These are NOT the render-metadata
+-- title/artist (RENDER_METADATA) — they live on the project itself and feed
+-- neither file tags nor filename templates.
+--
+-- Reachable, verified empirically on REAPER 7.78/linux:
+--   * GetSetProjectInfo_String descriptors "PROJECT_TITLE" and "PROJECT_AUTHOR".
+--   * "PROJECT_AUTHOR" is the same value GetSetProjectAuthor() reads/writes
+--     (both reflect a change immediately). "PROJECT_TITLE" has no dedicated
+--     function — this descriptor is its only access path.
+--   * Unlike RENDER_METADATA, GET returns the actual stored VALUE (not a
+--     tag-name list), and SET overwrites the field rather than being additive.
+local PROJECT_NOTES_STRING_KEYS = {
+  title  = "PROJECT_TITLE",
+  author = "PROJECT_AUTHOR",
+}
+
+function project.project_get_notes_info(p)
+  local out = {}
+  for field, key in pairs(PROJECT_NOTES_STRING_KEYS) do
+    out[field] = select(2, reaper.GetSetProjectInfo_String(0, key, "", false)) or ""
+  end
+  return out
+end
+
+function project.project_set_notes_info(p)
+  local written = {}
+  for field, key in pairs(PROJECT_NOTES_STRING_KEYS) do
+    local value = p[field]
+    if value ~= nil and value ~= "" then
+      value = tostring(value)
+      reaper.GetSetProjectInfo_String(0, key, value, true)
+      written[field] = value
+    end
+  end
+  -- read back current values (including fields left untouched)
+  local current = {}
+  for field, key in pairs(PROJECT_NOTES_STRING_KEYS) do
+    current[field] = select(2, reaper.GetSetProjectInfo_String(0, key, "", false)) or ""
+  end
+  return {written = written, notes_info = current}
+end
+
 function project.project_main_action(p)
   -- Run a REAPER Main action by command_id. Used by high-level pipelines
   -- (e.g. bounce_stems uses action 40892 = render selected tracks to stems).

--- a/tests/test_project_metadata_tools.py
+++ b/tests/test_project_metadata_tools.py
@@ -1,0 +1,61 @@
+"""Tests for project render-metadata payload validation (project_tools).
+
+Pure logic only — no REAPER/IPC mocking, matching the pattern used by
+tests/test_marker_tools.py for markers_apply.
+"""
+
+import pytest
+
+from reaper_mcp.tools.project_tools import _build_metadata_payload
+from reaper_mcp_shared.error_codes import ReaperMCPError
+
+
+class TestBuildMetadataPayload:
+    def test_keeps_non_empty_fields(self):
+        out = _build_metadata_payload({
+            "title": "Andante",
+            "author": "Giang",
+            "album": "",
+            "comment": "",
+        })
+        assert out == {"title": "Andante", "author": "Giang"}
+
+    def test_all_empty_raises(self):
+        with pytest.raises(ReaperMCPError, match="at least one metadata field"):
+            _build_metadata_payload({"title": "", "author": "", "album": ""})
+
+    def test_no_fields_raises(self):
+        with pytest.raises(ReaperMCPError, match="at least one metadata field"):
+            _build_metadata_payload({})
+
+    def test_coerces_int_to_str(self):
+        # callers may pass numeric track numbers; they must be stringified
+        out = _build_metadata_payload({"track_number": 5})
+        assert out == {"track_number": "5"}
+
+    def test_field_length_cap(self):
+        too_long = "x" * 1025
+        with pytest.raises(ReaperMCPError, match="track_number too long"):
+            _build_metadata_payload({"track_number": too_long})
+
+    def test_field_length_cap_boundary_ok(self):
+        exactly_cap = "x" * 1024
+        out = _build_metadata_payload({"title": exactly_cap})
+        assert out == {"title": exactly_cap}
+
+    def test_multibyte_field_measured_in_bytes(self):
+        # 'é' is 2 bytes in UTF-8; 513 chars = 1026 bytes -> over the 1024 byte
+        # cap, even though the char count (513) is well under a naive char limit.
+        over_in_bytes = "é" * 513
+        assert len(over_in_bytes.encode("utf-8")) == 1026
+        assert len(over_in_bytes) == 513  # char count alone would pass
+        with pytest.raises(ReaperMCPError, match="too long"):
+            _build_metadata_payload({"comment": over_in_bytes})
+
+    def test_only_some_fields_too_long(self):
+        # a long field raises even when valid fields are also present
+        with pytest.raises(ReaperMCPError, match="album too long"):
+            _build_metadata_payload({
+                "title": "ok",
+                "album": "y" * 2000,
+            })

--- a/tests/test_project_notes_info_tools.py
+++ b/tests/test_project_notes_info_tools.py
@@ -1,0 +1,52 @@
+"""Tests for the Project Settings -> Notes tab Title/Author payload.
+
+project_set_notes_info reuses _build_metadata_payload (the same pure helper
+project_set_metadata uses) to enforce its "empty strings are ignored / at
+least one field required / per-field length cap" contract. These tests fix
+that contract for the Notes-tab field set {title, author}.
+
+Pure logic only — no REAPER/IPC mocking, matching test_project_metadata_tools.py.
+"""
+
+import pytest
+
+from reaper_mcp.tools.project_tools import _build_metadata_payload
+from reaper_mcp_shared.error_codes import ReaperMCPError
+
+
+class TestNotesInfoPayload:
+    def test_keeps_both_fields(self):
+        out = _build_metadata_payload({"title": "Andante D-Moll", "author": "glm-5.2"})
+        assert out == {"title": "Andante D-Moll", "author": "glm-5.2"}
+
+    def test_keeps_only_title(self):
+        out = _build_metadata_payload({"title": "Andante", "author": ""})
+        assert out == {"title": "Andante"}
+
+    def test_keeps_only_author(self):
+        out = _build_metadata_payload({"title": "", "author": "glm-5.2"})
+        assert out == {"author": "glm-5.2"}
+
+    def test_both_empty_raises(self):
+        with pytest.raises(ReaperMCPError, match="at least one metadata field"):
+            _build_metadata_payload({"title": "", "author": ""})
+
+    def test_title_length_cap(self):
+        with pytest.raises(ReaperMCPError, match="title too long"):
+            _build_metadata_payload({"title": "x" * 1025, "author": ""})
+
+    def test_author_length_cap(self):
+        with pytest.raises(ReaperMCPError, match="author too long"):
+            _build_metadata_payload({"title": "", "author": "y" * 2000})
+
+    def test_coerces_int_author(self):
+        # a numeric author (unlikely but possible) must stringify, not crash
+        out = _build_metadata_payload({"title": "", "author": 2026})
+        assert out == {"author": "2026"}
+
+    def test_multibyte_title_measured_in_bytes(self):
+        # 'ü' is 2 bytes in UTF-8; 513 chars = 1026 bytes -> over the byte cap
+        over = "ü" * 513
+        assert len(over.encode("utf-8")) == 1026
+        with pytest.raises(ReaperMCPError, match="too long"):
+            _build_metadata_payload({"title": over, "author": ""})


### PR DESCRIPTION
Closes #8.

Adds four tools for project metadata that MCP could not reach: the render metadata REAPER embeds into rendered files, and the Title/Author fields of the Project Settings → Notes tab. Additive throughout — no existing tool changes signature or behaviour.

## Why two separate feature sets in one PR

They look like the same thing and are not — that distinction is most of the value here. REAPER holds this information in three unrelated places:

| Where | Descriptor | Reads back? |
|---|---|---|
| Notes free text | `GetSetProjectNotes` | yes (already covered by `project_get_notes`) |
| Notes tab Title/Author | `PROJECT_TITLE` / `PROJECT_AUTHOR` | yes, actual values |
| Render metadata | `RENDER_METADATA` | **no** — write-only |

Documenting either one alone would invite exactly the confusion this PR resolves.

## Changes

**Lua** (`reaper_mcp_server.lua`)
* `project_get_metadata` / `project_set_metadata` — maps ten logical fields onto ID3/VORBIS/APE tag names, one `"TAG|value"` write per tag.
* `project_get_notes_info` / `project_set_notes_info` — `PROJECT_TITLE` / `PROJECT_AUTHOR`, with read-back of untouched fields.
* Both blocks carry a comment header recording the empirically established API behaviour (see below).

**Python** (`project_tools.py`)
* The four tools, plus `_build_metadata_payload` — shared validation extracted as pure logic so the contract is unit-testable without REAPER.

**Tests** (`test_project_metadata_tools.py`, `test_project_notes_info_tools.py`)
* 16 tests: partial field sets, all-empty rejection, int coercion, the 1024-byte cap including its exact boundary, multi-byte input measured in bytes rather than characters, and mixed valid/oversized fields.

## RENDER_METADATA behaviour worth recording

Established on REAPER 7.78/Linux; not spelled out in the SDK docs:

* SET honors only the **first** `"TAG|value"` pair if several are concatenated → one write per tag.
* SET is **additive**; new tags don't erase existing ones.
* GET returns tag *names* only (`"ID3:TIT2;ID3:TPE1"`) — the **values are write-only**.
* CLEAR is `"TAG|"` with an empty value.

`project_get_metadata` therefore returns `fields_set` plus the raw `tags_present` list instead of fabricating values it cannot read.

`PROJECT_TITLE` / `PROJECT_AUTHOR` behave the opposite way: GET returns real values, SET overwrites. `PROJECT_AUTHOR` is the same value `GetSetProjectAuthor()` uses; `PROJECT_TITLE` has no dedicated function at all.

## Verification

Full suite green. Live-verified against REAPER 7.78 on Linux: values set through the tools appear in Project Settings and the Render dialog, and survive into rendered files as tags. In use in an agent-driven orchestral project, where render metadata was otherwise the one step that still needed a human in the loop.
