### PR TITLE
fix(fx_set_preset): verify the preset changed, drop the parameter dump

### DIFF
--- a/reaper_mcp/tools/fx_tools.py
+++ b/reaper_mcp/tools/fx_tools.py
@@ -176,13 +176,31 @@ def register(mcp: FastMCP):
         return await client.execute("fx_get_preset", track_index=track_index, fx_index=fx_index)
 
     @mcp.tool()
-    async def fx_set_preset(track_index: int, fx_index: int, preset_name: str) -> dict:
-        """Load preset by name.
+    async def fx_set_preset(
+        track_index: int,
+        fx_index: int,
+        preset_name: str,
+        include_params: bool = False,
+    ) -> dict:
+        """Load preset by name. Returns the resulting preset, not the parameters.
+
+        The name must match the plugin's own spelling. Some plugins report
+        names padded to a fixed width (e.g. KORG TRINITY pads to 16 chars),
+        and the padded form is what has to be passed. Take the name from
+        fx_get_preset or fx_navigate_preset rather than from REAPER's
+        presets/*.ini, which stores it trimmed.
+
+        If the preset does not actually change, this raises instead of
+        reporting success.
 
         Args:
             track_index: 0-based track index.
             fx_index: 0-based FX chain index.
-            preset_name: Preset name.
+            preset_name: Preset name, exactly as the plugin reports it.
+            include_params: Also return the plugin's full parameter list.
+                Off by default — on large instruments that runs to tens of
+                thousands of characters. Use fx_get_params when the
+                parameters are what you actually want.
         """
         if track_index < 0:
             raise ReaperMCPError(ErrorCode.VALUE_OUT_OF_RANGE, "track_index must be >= 0")
@@ -190,7 +208,13 @@ def register(mcp: FastMCP):
             raise ReaperMCPError(ErrorCode.VALUE_OUT_OF_RANGE, "fx_index must be >= 0")
         if not preset_name:
             raise ReaperMCPError(ErrorCode.MISSING_PARAMETER, "preset_name cannot be empty")
-        return await client.execute("fx_set_preset", track_index=track_index, fx_index=fx_index, preset_name=preset_name)
+        return await client.execute(
+            "fx_set_preset",
+            track_index=track_index,
+            fx_index=fx_index,
+            preset_name=preset_name,
+            include_params=include_params,
+        )
 
     @mcp.tool()
     async def fx_navigate_preset(track_index: int, fx_index: int, direction: int) -> dict:

--- a/reaper_scripts/reaper_mcp_server.lua
+++ b/reaper_scripts/reaper_mcp_server.lua
@@ -1396,13 +1396,52 @@ function fx.fx_get_preset(p)
   return {fx_name = fx_name, preset = preset, preset_index = pi, total_presets = total_presets}
 end
 
+-- Trim surrounding whitespace. Preset names are compared trimmed because some
+-- plugins report them padded to a fixed width (KORG TRINITY pads to 16 chars),
+-- while REAPER's own presets/*.ini stores the same names trimmed.
+local function trim_ws(s)
+  return (tostring(s):gsub("^%s*(.-)%s*$", "%1"))
+end
+
 function fx.fx_set_preset(p)
   local tr, idx, err = get_track(p)
   if not tr then return nil, err end
   if not p.preset_name then return nil, "Missing parameter: preset_name" end
   local fi = require_int(p, "fx_index")
-  reaper.TrackFX_SetPreset(tr, fi, p.preset_name)
-  return build_fx_params(tr, fi)
+  local requested = tostring(p.preset_name)
+
+  local applied = reaper.TrackFX_SetPreset(tr, fi, requested)
+  local _, active = reaper.TrackFX_GetPreset(tr, fi, "")
+  active = active or ""
+
+  -- Verify against what is actually loaded instead of trusting the call:
+  -- TrackFX_SetPreset can leave the preset untouched when the name does not
+  -- match the plugin's exact spelling, and the caller would otherwise get a
+  -- success response for a no-op.
+  if not applied or trim_ws(active) ~= trim_ws(requested) then
+    return nil, string.format(
+      "preset not applied: requested %q, still active is %q. The name must "
+      .. "match the plugin's spelling; some plugins pad to a fixed width. Read "
+      .. "it from fx_get_preset or fx_navigate_preset — REAPER's presets/*.ini "
+      .. "stores names trimmed and is not a reliable source.",
+      requested, active)
+  end
+
+  local pi, total_presets = reaper.TrackFX_GetPresetIndex(tr, fi)
+  local _, fx_name = reaper.TrackFX_GetFXName(tr, fi, "")
+  local result = {
+    fx_name = fx_name,
+    preset = active,
+    preset_index = pi,
+    total_presets = total_presets,
+  }
+  -- Opt-in only: the full parameter list runs to tens of thousands of
+  -- characters on large instruments and is rarely what a caller wants back
+  -- from a preset switch. fx_get_params covers the case where it is.
+  if p.include_params then
+    result.params = build_fx_params(tr, fi)
+  end
+  return result
 end
 
 function fx.fx_navigate_preset(p)

--- a/tests/test_fx_preset_tools.py
+++ b/tests/test_fx_preset_tools.py
@@ -1,0 +1,104 @@
+"""Tests for fx_set_preset's name matching and validation.
+
+Pure logic — no REAPER/IPC mocking needed, matching the pattern of
+test_send_tools.py and test_item_tools.py.
+
+The verification itself lives in the Lua handler (fx.fx_set_preset), which
+compares the requested name against what is actually loaded afterwards. The
+comparison rule is mirrored here so its behaviour is pinned down and
+documented: it is the part that decides whether a caller gets a result or an
+error, and getting it wrong in either direction is costly — too strict and
+legitimate calls fail, too loose and silent no-ops come back as success.
+"""
+
+import pytest
+
+from reaper_mcp_shared.error_codes import ReaperMCPError, ErrorCode
+
+
+class TestPresetNameComparison:
+    """Mirror of the trim-based comparison in Lua's fx.fx_set_preset.
+
+    Background: plugins may report preset names padded to a fixed width —
+    KORG TRINITY pads every name to 16 characters — while REAPER's own
+    presets/*.ini stores the same names trimmed. A caller who took the name
+    from that file passes an unpadded string, TrackFX_SetPreset does not
+    apply it, and without this check the tool would report success for a
+    preset that never changed.
+    """
+
+    def _matches(self, requested: str, active: str) -> bool:
+        """Mirror of `trim_ws(active) ~= trim_ws(requested)` in the Lua handler."""
+        return str(active).strip() == str(requested).strip()
+
+    def test_identical_names_match(self):
+        assert self._matches("Trinity Overture", "Trinity Overture")
+
+    def test_unpadded_request_matches_padded_active(self):
+        """The .ini spelling vs. what the plugin reports back."""
+        assert self._matches("Shakoto", "Shakoto         ")
+
+    def test_padded_request_matches_unpadded_active(self):
+        """Symmetric: a plugin may report trimmed while the caller padded."""
+        assert self._matches("Shakoto         ", "Shakoto")
+
+    def test_both_padded_match(self):
+        assert self._matches("Shakoto         ", "Shakoto         ")
+
+    def test_different_names_do_not_match(self):
+        """The no-op case: preset stayed on whatever was loaded before."""
+        assert not self._matches("Shakoto", "JamYourButtOff !")
+
+    def test_padding_does_not_make_different_names_equal(self):
+        assert not self._matches("Shakoto  ", "Shakotos")
+
+    def test_inner_whitespace_is_significant(self):
+        """Only surrounding whitespace is ignored, never inner."""
+        assert not self._matches("Big Perc Organ", "BigPercOrgan")
+
+    def test_empty_active_never_matches_a_real_name(self):
+        """TrackFX_GetPreset returns "" when it cannot report a preset."""
+        assert not self._matches("Shakoto", "")
+
+    def test_case_is_significant(self):
+        """No case folding — REAPER matches names case-sensitively."""
+        assert not self._matches("shakoto", "Shakoto")
+
+
+class TestFxSetPresetValidation:
+    """Mirror of the argument validation in fx_set_preset."""
+
+    def _validate(self, track_index: int, fx_index: int, preset_name: str):
+        if track_index < 0:
+            raise ReaperMCPError(
+                ErrorCode.VALUE_OUT_OF_RANGE, "track_index must be >= 0"
+            )
+        if fx_index < 0:
+            raise ReaperMCPError(
+                ErrorCode.VALUE_OUT_OF_RANGE, "fx_index must be >= 0"
+            )
+        if not preset_name:
+            raise ReaperMCPError(
+                ErrorCode.MISSING_PARAMETER, "preset_name cannot be empty"
+            )
+
+    def test_valid_arguments_pass(self):
+        self._validate(0, 0, "Trinity Overture")
+
+    def test_negative_track_index_rejected(self):
+        with pytest.raises(ReaperMCPError):
+            self._validate(-1, 0, "Trinity Overture")
+
+    def test_negative_fx_index_rejected(self):
+        with pytest.raises(ReaperMCPError):
+            self._validate(0, -1, "Trinity Overture")
+
+    def test_empty_preset_name_rejected(self):
+        with pytest.raises(ReaperMCPError):
+            self._validate(0, 0, "")
+
+    def test_whitespace_only_name_is_not_empty(self):
+        """A padded-to-blank name is still a string the plugin might use;
+        rejecting it here would be a guess, so it is passed through and the
+        Lua-side verification decides."""
+        self._validate(0, 0, "   ")


### PR DESCRIPTION
Closes #10.

Two defects in one function, both of which present as "it looks like it worked".

## 1. The response was the entire parameter list

`fx_set_preset` ended in `return build_fx_params(tr, fi)`. On KORG TRINITY that is **68,905 characters across 2,773 lines** — per call. My MCP client truncated it and wrote the payload to a file, so the agent got no confirmation at all and had to follow up with `fx_get_preset` to learn whether the preset had loaded.

It now returns the same compact shape `fx_get_preset` and `fx_navigate_preset` already produce. Callers who genuinely want the parameters pass `include_params=True`; the default is off.

## 2. A wrong name was a silent no-op

This is the part I did not expect. `TrackFX_SetPreset` leaves the preset untouched when the name does not match the plugin's spelling — and plugins may pad names to a fixed width. TRINITY pads every one to 16 characters:

```
[0]=<Trinity Overture> len=16
[6]=<Killer Miller!  > len=16
[7]=<Shakoto         > len=16
```

So `fx_set_preset(0, 0, "Shakoto")` changed nothing and reported success, while `"Shakoto         "` worked. What makes it genuinely nasty is that REAPER's **own** preset file stores the names trimmed:

```ini
; ~/.config/REAPER/presets/vst3-TRINITY-builtin.ini
00008=Shakoto
```

The most obvious place to look up a name is the one place that hands you a string the call will reject without saying so. And names that happen to be exactly 16 characters — `"Trinity Overture"`, `"Old School Split"` — work fine, so the failure looks random until you count characters.

The fix does not guess or re-pad. It verifies: after setting, read back what is actually loaded and compare trimmed on both sides. If it does not match, raise instead of returning success. That also covers the case where `TrackFX_SetPreset` returns true but nothing happens, which checking the return value alone would miss.

## Tests

14 new cases in `tests/test_fx_preset_tools.py`, following the mirror-the-logic pattern of `test_send_tools.py`. They pin the comparison rule in both directions (padded request vs. trimmed active and vice versa) and the cases where it must **not** match: names that padding might otherwise equalise, inner whitespace, case differences, empty `active`. Full suite: 206 passed.

## Verification

Lua syntax checked by compiling the file through a Lua 5.3 interpreter. Verified live against REAPER 7.78 (Linux) with KORG TRINITY after the change:

**Trimmed name — an error now, instead of a silent success:**

```
fx_set_preset(0, 0, "Shakoto")
→ COMMAND_FAILED: preset not applied: requested "Shakoto", still active is
  "Bass & Piano/SW1". The name must match the plugin's spelling; some plugins
  pad to a fixed width. Read it from fx_get_preset or fx_navigate_preset —
  REAPER's presets/*.ini stores names trimmed and is not a reliable source.
```

**Correct name — compact response, preset audibly switched:**

```json
{"fx_name": "VST3i: TRINITY (KORG)", "preset": "Shakoto         ",
 "preset_index": 7, "total_presets": 128}
```

**`include_params=True` — full list returns on request:** 75,745 characters, containing both the four compact fields and a `params` array of 460 entries.

Branched from current `main` (0.6.3); the Lua handler merged cleanly with the heartbeat-staleness changes in `ec73f77`.
