### PR TITLE
fix(watchdog): allow opting out of the supersede self-retirement path

### DIFF
--- a/reaper_mcp/main.py
+++ b/reaper_mcp/main.py
@@ -23,9 +23,13 @@ import time
 # to a platform check — a no-op on a system that's already UTF-8, and must
 # happen before anything touches stdio (earlier than the FastMCP import even
 # risks it), so this is the very first thing in the file.
-sys.stdout.reconfigure(encoding="utf-8")
-sys.stdin.reconfigure(encoding="utf-8")
-sys.stderr.reconfigure(encoding="utf-8")
+# Guarded per stream: under pytest (and in embedded hosts) sys.stdin/stdout
+# can be a substitute object without .reconfigure, and an AttributeError here
+# would make the module unimportable rather than just skipping a no-op.
+for _stream in (sys.stdout, sys.stdin, sys.stderr):
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is not None:
+        _reconfigure(encoding="utf-8")
 
 from mcp.server.fastmcp import FastMCP
 
@@ -62,6 +66,33 @@ def _claim_generation(ppid: int) -> None:
         os.replace(tmp, path)  # atomic — readers never see a torn write
     except OSError:
         pass
+
+
+def supersede_enabled(env: dict | None = None) -> bool:
+    """Whether the "a newer server took over" self-retirement path is active.
+
+    Set REAPER_MCP_NO_SUPERSEDE=1 to switch it off. Needed for clients that
+    open more than one connection under a single parent process: the
+    generation slot is keyed by parent PID, so a second concurrent
+    connection from the same client looks identical to that client having
+    reconnected, and the first server retires while its connection is still
+    in active use. Observed with Claude Desktop, which spawns two servers
+    under one parent — the client keeps talking to the first one, which
+    exits, and every tool call then hangs with no response.
+
+    Switching this off leaves the two mechanisms that actually own shutdown
+    intact: stdio EOF when the client closes the pipes, and the
+    parent-liveness watchdog. Those cover the normal cases; this path is
+    belt-and-braces for clients that reconnect without cleaning up.
+    """
+    if env is None:
+        env = os.environ
+    return env.get("REAPER_MCP_NO_SUPERSEDE", "").strip().lower() not in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
 
 
 def _superseded(ppid: int) -> bool:
@@ -128,9 +159,10 @@ def _watch_parent(poll_seconds: float = 3.0, confirmations_required: int = 3) ->
     """
     ppid = os.getppid()
     consecutive_dead = 0
+    check_superseded = supersede_enabled()
     while True:
         time.sleep(poll_seconds)
-        if _superseded(ppid):
+        if check_superseded and _superseded(ppid):
             os._exit(0)
         if _parent_alive(ppid):
             consecutive_dead = 0

--- a/tests/test_supersede_opt_out.py
+++ b/tests/test_supersede_opt_out.py
@@ -1,0 +1,47 @@
+"""Tests for the REAPER_MCP_NO_SUPERSEDE opt-out in reaper_mcp/main.py.
+
+The supersede path retires a server when a newer one claims the generation
+slot for the same parent PID. That assumes one connection per client, which
+does not hold for every MCP client — Claude Desktop opens two servers under
+a single parent process, and the first one then exits while the client is
+still using it, leaving every tool call to hang.
+
+`supersede_enabled` takes the environment as an argument so the parsing can
+be tested without touching os.environ or importing the whole server.
+"""
+
+import pytest
+
+from reaper_mcp.main import supersede_enabled
+
+
+class TestSupersedeOptOut:
+    def test_enabled_by_default(self):
+        """Unset variable keeps the existing behaviour — no silent change."""
+        assert supersede_enabled({}) is True
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+    def test_recognised_off_values(self, value):
+        assert supersede_enabled({"REAPER_MCP_NO_SUPERSEDE": value}) is False
+
+    @pytest.mark.parametrize("value", ["TRUE", "Yes", "On", "1"])
+    def test_case_insensitive(self, value):
+        assert supersede_enabled({"REAPER_MCP_NO_SUPERSEDE": value}) is False
+
+    @pytest.mark.parametrize("value", [" 1", "1 ", "  true  "])
+    def test_surrounding_whitespace_tolerated(self, value):
+        """Values coming from a JSON config or a shell export often carry
+        stray whitespace; that should not silently re-enable the path."""
+        assert supersede_enabled({"REAPER_MCP_NO_SUPERSEDE": value}) is False
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+    def test_other_values_leave_it_enabled(self, value):
+        """Anything that is not an explicit opt-out keeps the default. An
+        unrecognised value must not disable a safety mechanism by accident."""
+        assert supersede_enabled({"REAPER_MCP_NO_SUPERSEDE": value}) is True
+
+    def test_reads_os_environ_when_no_argument_given(self, monkeypatch):
+        monkeypatch.setenv("REAPER_MCP_NO_SUPERSEDE", "1")
+        assert supersede_enabled() is False
+        monkeypatch.delenv("REAPER_MCP_NO_SUPERSEDE")
+        assert supersede_enabled() is True


### PR DESCRIPTION
Closes #12.

The supersede path keys its generation slot by parent PID, which assumes one connection per client. Claude Desktop opens two servers under one parent — the second claims the slot, the first exits while the client is still using it, and every tool call then hangs with no response.

## Change

`REAPER_MCP_NO_SUPERSEDE=1` switches that path off. Opt-in only: the default is unchanged, and only an explicit `1`/`true`/`yes`/`on` disables it, so an unrecognised value cannot silently drop a safety mechanism. stdio EOF and the parent-liveness watchdog — the mechanisms that actually own shutdown — stay in place.

Also guards the startup stdio reconfigure per stream. `sys.stdin` under pytest is a substitute object without `.reconfigure`, and the resulting `AttributeError` makes `reaper_mcp.main` unimportable. That is why no existing test imports it, and it had to be fixed before this change could be tested at all.

## Verification

Reproduced without any MCP client — two servers under one parent process, isolated `TMPDIR` so the production IPC directory stays untouched:

```
ohne Variable (Default)      erster=BEENDET  zweiter=lebt
mit NO_SUPERSEDE=1           erster=lebt     zweiter=lebt
```

The default reproduces the Claude Desktop failure exactly; the variable prevents it. Re-run on this branch after rebasing onto current `main` (0.6.3).

15 new tests cover the accepted values, case folding, surrounding whitespace (values arriving from a JSON config or a shell export), the fail-safe default for unknown values, and that the argument-less call reads `os.environ`. Full suite: **211 passed**.

In use here since: Claude Desktop and Claude Code now run against the same bridge simultaneously, serialised by the existing IPC mutex.

Issue #12 carries the process-level evidence from the live session — watcher output, the client log, and the IPC state captured while the call was hanging.