### PR TITLE
feat(tools): MIDI Program Change / Bank Select and program name listing

### DIFF
--- a/reaper_mcp/tools/midi_tools.py
+++ b/reaper_mcp/tools/midi_tools.py
@@ -224,6 +224,87 @@ def register(mcp: FastMCP):
     # ── CC (Control Change) Operations ───────────────────────
 
     @mcp.tool()
+    @mcp.tool()
+    async def midi_insert_program_change(
+        track_index: int,
+        item_index: int,
+        channel: int,
+        program: int,
+        position: float,
+        bank_msb: int | None = None,
+        bank_lsb: int | None = None,
+    ) -> dict:
+        """Insert a MIDI Program Change, optionally preceded by Bank Select.
+
+        This is how emulations of classic hardware switch sounds. Their
+        program list is often inert through the FX preset selector while
+        Program Change works — check with midi_list_programs which programs
+        a track offers.
+
+        Bank Select (CC 0 / CC 32) is written before the Program Change when
+        given, one tick apart so the order cannot be reordered away. Omit
+        both for instruments with a single bank.
+
+        Args:
+            track_index: 0-based track index.
+            item_index: MIDI item index.
+            channel: 0-15, 0-based (REAPER's UI shows 1-16).
+            program: 0-127, 0-based (the UI usually shows 1-128).
+            position: Seconds. Place it before the notes it should affect.
+            bank_msb: Optional Bank Select MSB (CC 0), 0-127.
+            bank_lsb: Optional Bank Select LSB (CC 32), 0-127.
+        """
+        if track_index < 0:
+            raise ReaperMCPError(ErrorCode.VALUE_OUT_OF_RANGE, "track_index must be >= 0")
+        if channel < 0 or channel > 15:
+            raise ReaperMCPError(ErrorCode.VALUE_OUT_OF_RANGE, "Channel must be 0-15")
+        if program < 0 or program > 127:
+            raise ReaperMCPError(
+                ErrorCode.VALUE_OUT_OF_RANGE,
+                "program must be 0-127 (0-based; the UI usually shows 1-128)",
+            )
+        for label, val in (("bank_msb", bank_msb), ("bank_lsb", bank_lsb)):
+            if val is not None and not (0 <= val <= 127):
+                raise ReaperMCPError(
+                    ErrorCode.VALUE_OUT_OF_RANGE, f"{label} must be 0-127, got {val}"
+                )
+        params = {
+            "track_index": track_index,
+            "item_index": item_index,
+            "channel": channel,
+            "program": program,
+            "position": position,
+        }
+        if bank_msb is not None:
+            params["bank_msb"] = bank_msb
+        if bank_lsb is not None:
+            params["bank_lsb"] = bank_lsb
+        return await client.execute("midi_insert_program_change", **params)
+
+    @mcp.tool()
+    async def midi_list_programs(track_index: int) -> dict:
+        """List the MIDI program names a track's instrument exposes.
+
+        Returns `supplier` (the plugin providing the list, null if none) and
+        `programs` as {program, name} pairs, program numbers 0-based.
+
+        Names come back exactly as the plugin reports them, including any
+        fixed-width padding, so they can be passed straight to fx_set_preset
+        — unlike the names in REAPER's presets/*.ini, which are stored
+        trimmed and will be rejected.
+
+        Whether a plugin honors a Program Change is a separate question from
+        whether it publishes names here; some publish a full list and still
+        only respond to the preset selector, or the other way round.
+
+        Args:
+            track_index: 0-based track index.
+        """
+        if track_index < 0:
+            raise ReaperMCPError(ErrorCode.VALUE_OUT_OF_RANGE, "track_index must be >= 0")
+        return await client.execute("midi_list_programs", track_index=track_index)
+
+    @mcp.tool()
     async def midi_insert_cc(
         track_index: int,
         item_index: int,

--- a/reaper_scripts/reaper_mcp_server.lua
+++ b/reaper_scripts/reaper_mcp_server.lua
@@ -2676,6 +2676,106 @@ function midi.midi_delete_all_notes(p)
   return {cleared = true, deleted_count = count}
 end
 
+-- Program Change und Bank Select.
+--
+-- MIDI_InsertCC nimmt den Nachrichtentyp als chanmsg-Parameter; midi_insert_cc
+-- verdrahtet ihn auf 0xB0 (Control Change), sodass Program Change (0xC0) bisher
+-- nicht erreichbar war. Genau der schaltet aber bei Emulationen klassischer
+-- Hardware das Programm um — der Preset-Selector bleibt dort wirkungslos.
+--
+-- Reihenfolge: Bank Select MSB (CC 0) und LSB (CC 32) muessen VOR dem Program
+-- Change liegen, sonst waehlt das Plugin aus der alten Bank. Die drei Events
+-- werden deshalb um je einen Tick gestaffelt. Ein Test auf REAPER 7.78 zeigt
+-- zwar, dass MIDI_Sort die Einfuegereihenfolge auch bei identischer Position
+-- beibehaelt, aber das ist nirgends zugesichert — ein Tick (1/960 Viertel) ist
+-- musikalisch bedeutungslos und macht das Ergebnis unabhaengig davon.
+--
+-- Program Change traegt nur EIN Datenbyte, msg3 bleibt 0. Kanaele und
+-- Programmnummern sind 0-basiert (auf dem Draht), waehrend REAPERs Oberflaeche
+-- ab 1 zaehlt.
+function midi.midi_insert_program_change(p)
+  local it, take, idx, err = get_midi_take(p)
+  if not take then return nil, err end
+  if p.position == nil or p.channel == nil or p.program == nil then
+    return nil, "Missing parameter: position/channel/program"
+  end
+
+  local ch = clamp(math.floor(p.channel), 0, 15)
+  local prog = math.floor(p.program)
+  if prog < 0 or prog > 127 then
+    return nil, "program must be 0-127 (0-based; the UI usually shows 1-128)"
+  end
+
+  local msb, lsb
+  if p.bank_msb ~= nil then
+    msb = math.floor(p.bank_msb)
+    if msb < 0 or msb > 127 then return nil, "bank_msb must be 0-127" end
+  end
+  if p.bank_lsb ~= nil then
+    lsb = math.floor(p.bank_lsb)
+    if lsb < 0 or lsb > 127 then return nil, "bank_lsb must be 0-127" end
+  end
+
+  local ppq = reaper.MIDI_GetPPQPosFromProjTime(take, p.position)
+  local tick = 0
+
+  reaper.Undo_BeginBlock()
+  if msb ~= nil then
+    reaper.MIDI_InsertCC(take, false, false, ppq + tick, 0xB0, ch, 0, msb)
+    tick = tick + 1
+  end
+  if lsb ~= nil then
+    reaper.MIDI_InsertCC(take, false, false, ppq + tick, 0xB0, ch, 32, lsb)
+    tick = tick + 1
+  end
+  reaper.MIDI_InsertCC(take, false, false, ppq + tick, 0xC0, ch, prog, 0)
+  reaper.MIDI_Sort(take)
+  reaper.Undo_EndBlock("MCP: midi_insert_program_change", -1)
+
+  local _, _, ccs = reaper.MIDI_CountEvts(take)
+  return {
+    inserted = {
+      channel = ch,
+      program = prog,
+      bank_msb = msb,
+      bank_lsb = lsb,
+      position = p.position,
+    },
+    total_ccs = ccs,
+  }
+end
+
+-- Programmnamen einer Spur auflisten.
+--
+-- HasTrackMIDIPrograms meldet, welches Plugin die Liste liefert (oder nichts),
+-- EnumTrackMIDIProgramNames die Namen. Beide erwarten den Track-INDEX, nicht
+-- das MediaTrack-Handle. Die Namen kommen so zurueck, wie das Plugin sie fuehrt
+-- — inklusive Padding auf feste Breite — und sind damit direkt als preset_name
+-- fuer fx_set_preset verwendbar.
+function midi.midi_list_programs(p)
+  local tr, idx, err = get_track(p)
+  if not tr then return nil, err end
+
+  local supplier = reaper.HasTrackMIDIPrograms(idx)
+  if supplier == nil or supplier == "" then
+    return {track_index = idx, supplier = nil, count = 0, programs = {}}
+  end
+
+  local programs = {}
+  for pn = 0, 127 do
+    local ok, name = reaper.EnumTrackMIDIProgramNames(idx, pn, "")
+    if not ok then break end
+    programs[#programs + 1] = {program = pn, name = name}
+  end
+
+  return {
+    track_index = idx,
+    supplier = supplier,
+    count = #programs,
+    programs = programs,
+  }
+end
+
 function midi.midi_insert_cc(p)
   local it, take, idx, err = get_midi_take(p)
   if not take then return nil, err end

--- a/tests/test_midi_program_change.py
+++ b/tests/test_midi_program_change.py
@@ -1,0 +1,108 @@
+"""Tests for midi_insert_program_change / midi_list_programs validation.
+
+Pure validation logic — no REAPER/IPC mocking needed, matching the pattern of
+test_send_tools.py and test_fx_preset_tools.py.
+
+Both the channel and the program number are 0-based on the wire while REAPER's
+UI counts from 1, so the boundaries are where a caller is most likely to be off
+by one. These pin them down.
+"""
+
+import pytest
+
+from reaper_mcp_shared.error_codes import ReaperMCPError, ErrorCode
+
+
+class TestProgramChangeValidation:
+    """Mirror of the validation in midi_insert_program_change."""
+
+    def _validate(self, track_index=0, channel=0, program=0,
+                  bank_msb=None, bank_lsb=None):
+        if track_index < 0:
+            raise ReaperMCPError(
+                ErrorCode.VALUE_OUT_OF_RANGE, "track_index must be >= 0"
+            )
+        if channel < 0 or channel > 15:
+            raise ReaperMCPError(ErrorCode.VALUE_OUT_OF_RANGE, "Channel must be 0-15")
+        if program < 0 or program > 127:
+            raise ReaperMCPError(
+                ErrorCode.VALUE_OUT_OF_RANGE,
+                "program must be 0-127 (0-based; the UI usually shows 1-128)",
+            )
+        for label, val in (("bank_msb", bank_msb), ("bank_lsb", bank_lsb)):
+            if val is not None and not (0 <= val <= 127):
+                raise ReaperMCPError(
+                    ErrorCode.VALUE_OUT_OF_RANGE, f"{label} must be 0-127, got {val}"
+                )
+
+    def test_defaults_are_valid(self):
+        self._validate()
+
+    @pytest.mark.parametrize("channel", [0, 15])
+    def test_channel_boundaries(self, channel):
+        """0-based: channel 15 is what the UI calls 16."""
+        self._validate(channel=channel)
+
+    @pytest.mark.parametrize("channel", [-1, 16])
+    def test_channel_out_of_range(self, channel):
+        """16 is the classic off-by-one — the UI's highest channel."""
+        with pytest.raises(ReaperMCPError):
+            self._validate(channel=channel)
+
+    @pytest.mark.parametrize("program", [0, 127])
+    def test_program_boundaries(self, program):
+        self._validate(program=program)
+
+    @pytest.mark.parametrize("program", [-1, 128])
+    def test_program_out_of_range(self, program):
+        """128 is what the UI shows as the last program — one too many here."""
+        with pytest.raises(ReaperMCPError):
+            self._validate(program=program)
+
+    def test_bank_bytes_optional(self):
+        """Instruments with a single bank need no Bank Select at all."""
+        self._validate(bank_msb=None, bank_lsb=None)
+
+    def test_bank_msb_alone_is_allowed(self):
+        """Unlike the paired MIDI send channels, these are independent —
+        many devices only use the MSB."""
+        self._validate(bank_msb=2)
+
+    def test_bank_lsb_alone_is_allowed(self):
+        self._validate(bank_lsb=3)
+
+    @pytest.mark.parametrize("value", [0, 127])
+    def test_bank_boundaries(self, value):
+        self._validate(bank_msb=value, bank_lsb=value)
+
+    @pytest.mark.parametrize("value", [-1, 128])
+    def test_bank_msb_out_of_range(self, value):
+        with pytest.raises(ReaperMCPError):
+            self._validate(bank_msb=value)
+
+    @pytest.mark.parametrize("value", [-1, 128])
+    def test_bank_lsb_out_of_range(self, value):
+        with pytest.raises(ReaperMCPError):
+            self._validate(bank_lsb=value)
+
+    def test_zero_bank_is_not_treated_as_absent(self):
+        """Bank 0 is a real value; `if bank_msb:` would silently drop it.
+        The implementation checks `is not None` for exactly this reason."""
+        self._validate(bank_msb=0, bank_lsb=0)
+
+
+class TestListProgramsValidation:
+    """Mirror of the validation in midi_list_programs."""
+
+    def _validate(self, track_index: int):
+        if track_index < 0:
+            raise ReaperMCPError(
+                ErrorCode.VALUE_OUT_OF_RANGE, "track_index must be >= 0"
+            )
+
+    def test_valid_index(self):
+        self._validate(0)
+
+    def test_negative_index_rejected(self):
+        with pytest.raises(ReaperMCPError):
+            self._validate(-1)


### PR DESCRIPTION
Closes #14.

Two tools that together close the loop: find out which programs an instrument offers, then select one.

## `midi_insert_program_change`

`midi_insert_cc` hardcodes the message type to `0xB0`, so Program Change was unreachable even though `MIDI_InsertCC` takes it as a parameter. Bank Select already worked — CC 0 and CC 32 are ordinary controllers — so what was missing was precisely the message that switches.

Bank Select, when given, is written **before** the Program Change, one tick apart.

## On the staggering

Bank bytes must precede the Program Change or the plugin selects from the wrong bank. Measured on REAPER 7.78:

```
same position:      CC0@0 -> CC32@0 -> PC@0
staggered (1 tick): CC0@0 -> CC32@1 -> PC@2
```

`MIDI_Sort` preserves insertion order at identical positions. The implementation staggers anyway: stable sorting is not documented, one tick is 1/960 of a quarter note, and a wrong-bank selection surfaces as "wrong sound" — a symptom that is hard to trace back to event ordering.

## `midi_list_programs`

Wraps `HasTrackMIDIPrograms` and `EnumTrackMIDIProgramNames`, neither currently exposed. Returns `supplier` and `programs` as `{program, name}` pairs.

Names come back exactly as the plugin reports them, **including fixed-width padding**, which makes them directly usable as `preset_name` for `fx_set_preset` — unlike the names in `presets/*.ini`, which are trimmed and get rejected (see #10).

Deliberately a separate tool, because publishing names and honouring Program Change turn out to be independent: TRINITY exposes 128 programs with real factory names and ignores Program Change, ARP 2600 FX honours it while exposing generic slot names.

## Verification

End-to-end on KORG ARP 2600 FX, audible and visible in the plugin's own window. MIDI monitor capture of the generated item:

```
0:  C0 04 00 [Program Change] chan 1 val 4       <- first call, no bank
1:  90 30 64 [Note On] chan 1 note 48 vel 100
...
7:  B0 00 00 [CC0  Bank Select MSB] chan 1 val 0    <- second call
8:  B0 20 00 [CC32 Bank Select LSB] chan 1 val 0
9:  C0 1A 00 [Program Change] chan 1 val 26
10: 90 30 64 [Note On] chan 1 note 48 vel 100
```

Both code paths in one pass: the call at 0.0s omitted Bank Select, the one at 3.5s passed `bank_msb=0, bank_lsb=0`. The bank bytes land before the Program Change in MSB → LSB → PC order. Both chords are note-for-note identical, so the audible difference comes from the program change alone.

`midi_list_programs` returned 64 entries with `supplier: VST3: ARP 2600 FX (KORG)`.

Lua syntax checked by compiling through a Lua 5.3 interpreter.

## Tests

21 new cases. Channel and program are 0-based on the wire while REAPER's UI counts from 1, so the tests pin exactly the boundaries where a caller is likely to be off by one (`16` as channel, `128` as program). Also covered: bank `0` is a valid value and must not fall through as "unset" — the implementation checks `is not None` rather than truthiness, and a test holds that in place.

Full suite on this branch: **213 passed**.