### PR TITLE
Fix install.bat silently aborting under pyenv-win

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -10,7 +10,7 @@ echo.
 
 :: ── Check Python ──────────────────────────────────────────
 echo [1/6] Checking Python...
-python --version >nul 2>&1
+call python --version >nul 2>&1
 if %errorlevel% neq 0 (
     echo.
     echo  Python is not installed or not in PATH.
@@ -46,12 +46,12 @@ if %errorlevel% neq 0 (
         exit /b 1
     )
 )
-for /f "tokens=2" %%v in ('python --version 2^>^&1') do set PYVER=%%v
+for /f "tokens=2" %%v in ('call python --version 2^>^&1') do set PYVER=%%v
 echo   Found Python %PYVER%
 
 :: Verify Python >= 3.10
-for /f %%m in ('python -c "import sys; print(sys.version_info.minor)"') do set PY_MINOR=%%m
-for /f %%M in ('python -c "import sys; print(sys.version_info.major)"') do set PY_MAJOR=%%M
+for /f %%m in ('call python -c "import sys; print(sys.version_info.minor)"') do set PY_MINOR=%%m
+for /f %%M in ('call python -c "import sys; print(sys.version_info.major)"') do set PY_MAJOR=%%M
 if !PY_MAJOR! lss 3 (
     echo.
     echo  ERROR: Python 3.10+ is required, but you have Python %PYVER%
@@ -84,10 +84,10 @@ if defined VIRTUAL_ENV (
 :: Check if pip is available
 echo.
 echo [2/6] Installing reaper-mcp...
-python -m pip --version >nul 2>&1
+call python -m pip --version >nul 2>&1
 if %errorlevel% neq 0 (
     echo   pip not found, installing pip...
-    python -m ensurepip --upgrade >nul 2>&1
+    call python -m ensurepip --upgrade >nul 2>&1
     if !errorlevel! neq 0 (
         echo.
         echo  ERROR: pip is not installed and ensurepip failed.
@@ -107,13 +107,13 @@ if %errorlevel% neq 0 (
 :: (a real, confirmed incident, not a hypothetical). Uninstalling any
 :: old name first guarantees this install starts from a clean slate
 :: regardless of what was here before.
-python -m pip uninstall -y reaper-mcp reapermcp >nul 2>&1
+call python -m pip uninstall -y reaper-mcp reapermcp >nul 2>&1
 
 :: Install from local directory in editable mode, so tool changes in
 :: this checkout take effect without reinstalling - not because the
 :: package isn't on PyPI (it is, as xdarkzx-reaper-mcp).
 pushd "%~dp0"
-python -m pip install -e .
+call python -m pip install -e .
 if %errorlevel% neq 0 (
     echo.
     echo  ERROR: pip install failed. Try running as administrator,


### PR DESCRIPTION
## Summary

`install.bat` invokes `python` as a bare command in 8 places (version check, pip check, ensurepip, uninstall, editable install). Under pyenv-win, `python` resolves to `shims\python.bat` -- a batch file placed ahead of `python.exe` on PATH -- rather than to an executable.

In Windows batch, invoking another `.bat`/`.cmd` from inside a script **without `call`** transfers control into the child script and never returns; the parent script's execution just stops dead at that line. So the very first line of real work, `python --version >nul 2>&1` (install.bat:13), silently kills the entire installer with no error message, no prompt -- it just stops after printing `[1/6] Checking Python...`.

This only affects Python version managers whose shim is a `.bat` (pyenv-win here). A standard python.org or Microsoft Store install puts `python.exe` directly on PATH, so it never hits this path -- which is presumably why it went unnoticed.

## Fix

Prefix every `python` invocation in `install.bat` with `call`, so control returns to the script regardless of whether `python` resolves to an `.exe` or a `.bat` shim.

## Test plan

- [x] Reproduced the silent failure on a machine with pyenv-win active (`python` resolving to `shims\python.bat`): installer stopped immediately after `[1/6] Checking Python...`, exit code 0, no error output.
- [x] Applied the `call` fix and re-ran the installer end-to-end (all prompts answered `n`): all 6 steps completed successfully -- Python detected, `reaper-mcp` installed via editable install, REAPER auto-start configured, Claude Desktop/LM Studio steps skipped as requested, final "SETUP COMPLETE" banner shown.
- [x] Diff is minimal -- only the 8 `python` invocations gained `call`, no other logic changed.