### PR TITLE
fix(item_duplicate): resolve clone indices after insertion, and un-pool MIDI copies

### DIFF
--- a/reaper_scripts/reaper_mcp_server.lua
+++ b/reaper_scripts/reaper_mcp_server.lua
@@ -2259,6 +2259,21 @@ function item.take_set_reversed(p)
   return {item_index = idx, reversed = true}
 end
 
+-- Item state chunks carry identity that must not be shared between copies:
+-- GUID/IGUID identify the item and its take, and POOLEDEVTS identifies the
+-- MIDI event pool. Handing SetItemStateChunk a verbatim copy of the source
+-- chunk leaves all three shared, so a "copy" of a MIDI item is really a
+-- pooled alias -- editing either one edits both. Regenerate them so every
+-- clone is an independent object.
+local function reguid_item_chunk(chunk)
+  for _, key in ipairs({"GUID", "IGUID", "POOLEDEVTS"}) do
+    chunk = chunk:gsub("([\r\n]%s*" .. key .. " )%b{}", function(prefix)
+      return prefix .. reaper.genGuid("")
+    end)
+  end
+  return chunk
+end
+
 -- Duplicate an item N times at fixed spacing. Each copy preserves the
 -- source, take properties (pitch / playrate / fades / etc.) via
 -- SetItemStateChunk. Default spacing = item length (back-to-back).
@@ -2284,24 +2299,35 @@ function item.item_duplicate(p)
   reaper.Undo_BeginBlock()
   reaper.PreventUIRefresh(1)
 
-  -- Capture base index so we can hand back the new items' indices.
-  -- AddMediaItemToTrack appends to REAPER's global item list, so the
-  -- new indices are count_before, count_before+1, ... (sequential).
-  local count_before = reaper.CountMediaItems(0)
-
-  local clones = {}
+  local created = {}
   for i = 1, count do
     local new_pos = pos + (i * spacing)
     local new_item = reaper.AddMediaItemToTrack(tr)
     if new_item then
-      reaper.SetItemStateChunk(new_item, chunk, false)
+      reaper.SetItemStateChunk(new_item, reguid_item_chunk(chunk), false)
       reaper.SetMediaItemInfo_Value(new_item, "D_POSITION", new_pos)
-      clones[#clones+1] = {
-        item_index = count_before + (#clones),
-        position = new_pos,
-        length = len,
-      }
+      created[#created+1] = {ptr = new_item, position = new_pos}
     end
+  end
+
+  -- Resolve indices only once every insert is done. GetMediaItem() enumerates
+  -- the project's items in track order, then by position within each track, so
+  -- a new item lands inside its own track's block rather than at the end of
+  -- the list, and each insert shifts the index of everything after it. The
+  -- previous code assumed the clones were appended at CountMediaItems() and
+  -- handed back indices that pointed at unrelated items on later tracks.
+  local index_of = {}
+  for i = 0, reaper.CountMediaItems(0) - 1 do
+    index_of[reaper.GetMediaItem(0, i)] = i
+  end
+
+  local clones = {}
+  for _, c in ipairs(created) do
+    clones[#clones+1] = {
+      item_index = index_of[c.ptr],
+      position = c.position,
+      length = len,
+    }
   end
 
   reaper.PreventUIRefresh(-1)
@@ -2309,7 +2335,7 @@ function item.item_duplicate(p)
   reaper.Undo_EndBlock("MCP: item_duplicate x" .. count, -1)
 
   return {
-    source_item_index = idx,
+    source_item_index = index_of[it] or idx,
     copies_created = #clones,
     spacing_sec = spacing,
     clones = clones,

--- a/tests/test_item_duplicate_lua.py
+++ b/tests/test_item_duplicate_lua.py
@@ -1,0 +1,51 @@
+"""Source-level guards for the item_duplicate Lua handler.
+
+The handler lives in reaper_scripts/reaper_mcp_server.lua and, like every
+other Lua handler in this repo, has no runtime test — it needs a live REAPER.
+These two assertions are cheap regression guards for the specific defects
+fixed in this change, so a future refactor of item_duplicate can't silently
+reintroduce them:
+
+  1. clone chunks must be re-GUIDed, or MIDI copies come back pooled with
+     the source (editing one edits both);
+  2. clone indices must be resolved after every insert, because
+     AddMediaItemToTrack shifts the project-wide item enumeration.
+"""
+
+from pathlib import Path
+
+import pytest
+
+LUA = (
+    Path(__file__).resolve().parent.parent
+    / "reaper_scripts"
+    / "reaper_mcp_server.lua"
+)
+
+
+@pytest.fixture(scope="module")
+def item_duplicate_body() -> str:
+    src = LUA.read_text(encoding="utf-8")
+    start = src.index("function item.item_duplicate(p)")
+    end = src.index("\nend\n", src.index("copies_created", start))
+    return src[start:end]
+
+
+class TestItemDuplicateLua:
+    def test_clone_chunk_is_reguided(self, item_duplicate_body: str):
+        """The source chunk must not be handed to SetItemStateChunk verbatim."""
+        assert "reguid_item_chunk(chunk)" in item_duplicate_body
+        assert "SetItemStateChunk(new_item, chunk," not in item_duplicate_body
+
+    def test_clone_indices_resolved_after_insertion(self, item_duplicate_body: str):
+        """Indices come from a post-insert scan, not from CountMediaItems()."""
+        assert "index_of[c.ptr]" in item_duplicate_body
+        assert "count_before" not in item_duplicate_body
+
+
+def test_reguid_helper_covers_all_three_identity_keys():
+    src = LUA.read_text(encoding="utf-8")
+    helper = src[src.index("local function reguid_item_chunk"):]
+    helper = helper[: helper.index("\nend\n")]
+    for key in ("GUID", "IGUID", "POOLEDEVTS"):
+        assert f'"{key}"' in helper


### PR DESCRIPTION
Fixes #30.

`item_duplicate` returned `item_index` values that pointed at unrelated items,
and its MIDI "copies" shared an event pool with the source, so editing a copy
silently rewrote the original. Details and repro steps are in the issue.

## Changes

**`reaper_scripts/reaper_mcp_server.lua`**

1. **Indices are resolved after every insert.** `GetMediaItem(0, i)` enumerates
   in track order then position, not creation order, so `AddMediaItemToTrack`
   does not append to the end of the list — it inserts inside the source track's
   block and shifts everything after it. The handler now keeps the returned item
   pointers, and once all inserts are done builds a `pointer → index` map from a
   single pass over the project and reports each clone's real index.
   `source_item_index` is resolved the same way rather than echoing the input.

2. **New `reguid_item_chunk(chunk)` helper.** Regenerates `GUID`, `IGUID` and
   `POOLEDEVTS` with `reaper.genGuid()` before the chunk is applied to a clone,
   so each copy gets its own item identity, take identity and MIDI event pool.
   Only those three lines are rewritten; event data and every other chunk field
   are untouched.

**`tests/test_item_duplicate_lua.py`** (new)

Three source-level guards. Lua handlers have no runtime coverage in this repo —
they need a live REAPER — so these assert the two invariants directly against
the handler body, to stop a future refactor quietly reintroducing either defect.

## Verification

* `pytest tests/ -q` → 306 passed
* `ruff check .` → clean
* The `reguid_item_chunk` pattern was exercised against a representative item
  chunk (item `GUID`, take `IGUID`, `<SOURCE MIDI>` with `POOLEDEVTS` and event
  lines): all three identity fields replaced, event lines byte-identical.
* Behavioural check in REAPER: duplicating a MIDI item now yields a clone whose
  notes can be replaced without altering the source, and the reported
  `item_index` addresses the clone on a multi-track project.

## Notes for review

* The GUID rewrite is anchored to line starts (`[\r\n]%s*KEY %b{}`), so it can't
  match `IGUID` when looking for `GUID`, and can't touch GUID-shaped text
  elsewhere in the chunk.
* Behaviour is unchanged for the single-track, item-is-last case, which is
  presumably why the old index arithmetic looked correct in testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicated MIDI items are now created as independent items rather than sharing identity or pooled event data.
  * Duplicated items are correctly tracked even when inserted across different tracks, preventing incorrect item references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->